### PR TITLE
Fix #17: Allow to specify additional groups for jellyfin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ jellyfin_malloc_trim_threshold: 131072
 ```
 Disable glibc dynamic heap adjustment.
 
+```yml
+jellyfin_additional_unix_groups:
+  - render
+```
+**Optional:** Additional Unix groups to add to the Jellyfin user. This is useful for hardware transcoding.
+
+```yml
+
 ---
 ## Installing
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 jellyfin_name: jellyfin
 jellyfin_unix_user: "{{ jellyfin_name }}"
 jellyfin_unix_group: "{{ jellyfin_name }}"
+jellyfin_additional_unix_groups: []
 jellyfin_skip_restart: false
 
 # --- config files ---

--- a/tasks/prepare_host.yml
+++ b/tasks/prepare_host.yml
@@ -14,6 +14,7 @@
     name: "{{ jellyfin_unix_user }}"
     group: "{{ jellyfin_unix_group }}"
     groups: "{{ jellyfin_additional_unix_groups | list + ['{{ jellyfin_unix_group }}'] }}"
+    append: true
     state: present
     shell: /bin/false
 

--- a/tasks/prepare_host.yml
+++ b/tasks/prepare_host.yml
@@ -13,6 +13,7 @@
   ansible.builtin.user:
     name: "{{ jellyfin_unix_user }}"
     group: "{{ jellyfin_unix_group }}"
+    groups: "{{ jellyfin_additional_unix_groups | list + ['{{ jellyfin_unix_group }}'] }}"
     state: present
     shell: /bin/false
 


### PR DESCRIPTION
Adds the jellyfin_additional_unix_groups option which allows to specify a list of groups thats passed down to the ansible.builtin.user module.